### PR TITLE
Lazy loading of results from graph traversal.

### DIFF
--- a/src/ogre/pipe.clj
+++ b/src/ogre/pipe.clj
@@ -52,9 +52,17 @@
 ;; (defn step [^GremlinPipeline p e]
 ;;   (.step p e))
 
-(defn to-list! 
+(defn to-java-array-list! 
+  "Collects all results into java.util.ArrayList.  Useful when passed back to pipes/gremlin."
   [^GremlinPipeline p]
   (.toList p))
+
+(defn to-list! 
+  "Collects results lazily, makes efficient use of the the lazy nature of pipes/gremlin graph walking."
+  [^GremlinPipeline p]
+  (if (.hasNext p)
+    (let [n (.next p)]
+        (cons n (lazy-seq (to-list! p))))))
 
 (defn into-vec! 
   [^GremlinPipeline p]

--- a/test/ogre/branch/if_then_else_test.clj
+++ b/test/ogre/branch/if_then_else_test.clj
@@ -2,7 +2,13 @@
   (:use [clojure.test])
   (:require [ogre.core :as q]
             [ogre.tinkergraph :as g]
+            [ogre.pipe :as op]
             [ogre.test-util :as u]))
+
+(defn print-vals [vals]
+  (doseq [v vals]
+    (println (list (type v) v))))
+
 
 (deftest test-if-then-else-step
   (g/use-new-tinker-graph!)
@@ -14,4 +20,44 @@
                                       #(q/query % q/--> q/to-list!))
                       q/into-vec!)]
       (is (= 3 (count vs)))
+      (is (= 2 (count (set vs)))))))
+
+(deftest test-if-then-else-step-2
+  (g/use-new-tinker-graph!)
+  (testing "test_g_v1_out_ifThenElseXlang_eq_java__it__outX_name"
+    (let [vs (q/query (g/find-by-id 1)
+                      q/-->
+                      (q/if-then-else (partial u/prop-pred :lang = "java")
+                                      identity
+                                      ;; explicit use of to-java-array-list! which is interpretable by the
+                                      ;; pipes/gremlin graph walking code.
+                                      #(q/query % q/--> op/to-java-array-list!))
+                      op/into-vec!)]
+      (is (= 3 (count vs)))
       (is (= 2 (count (set vs)))))))                        
+
+
+(defn show-the-problem-above []
+  (g/use-new-tinker-graph!)
+  (let [vs (q/query (g/find-by-id 1)
+                    q/-->
+                    (q/if-then-else (partial u/prop-pred :lang = "java")
+                                    identity
+                                    #(q/query % q/--> op/to-java-array-list!))
+                    q/path
+                    q/into-vec!)
+        vs2 (q/query (g/find-by-id 1)
+                     q/-->
+                     (q/if-then-else (partial u/prop-pred :lang = "java")
+                                     identity
+                                     #(q/query % q/--> op/to-list!))
+                     q/path
+                     op/into-vec!)]
+    ;; When to-list return the empty clojure list,  the pipes/gremlin code does not realize
+    ;; that this is a failure,  so it merily returns this as a path with a null vertex.
+    (println "First case correctly determines that the path can be pruned away.")
+    (println (type vs))
+    (print-vals vs)
+    (println "Second case keeps it around.")
+    (println (type vs2))
+    (print-vals vs2)))


### PR DESCRIPTION
```
Changed to-list! to: "Collects results lazily, makes efficient use
of the the lazy nature of pipes/gremlin graph walking."

Note, this causes two tests to fail.  I then added two equivalent
tests which have been modified slightly and now pass. I believe
this is really a design decision.  Since the new way of running these 
tests is a bit awkward,  and could cause bugs...  on the other hand
there are many benefits from lazy loading of results,  and it is really
much more idiomatic for Gremlin.

See test/ogre/branch/if_then_else_test.clj and the function
show-the-problem-above for some "discussion" of this issue.
```
