### PR TITLE
Fix several unit tests that seemed not to test what was intended

### DIFF
--- a/test/ogre/side_effect/side_effect_test.clj
+++ b/test/ogre/side_effect/side_effect_test.clj
@@ -24,8 +24,8 @@
                       (q/side-effect (partial swap! lst conj))
                       (q/property :name)
                       q/into-vec!)]
-      (= 3 (count @lst))
-      (= #{"josh" "lop" "vadas"} (set names))))
+      (is (= 3 (count @lst)))
+      (is (= #{"josh" "lop" "vadas"} (set names)))))
 
   (testing "test_g_v1_out_sideEffectXfalseX_propertyXnameX"
     (let [lst (atom [])
@@ -35,8 +35,8 @@
                       (q/side-effect (constantly false))
                       (q/property :name)
                       q/into-vec!)]
-      (= 3 (count @lst))
-      (= #{"josh" "lop" "vadas"} (set names)))))
+      (is (= 3 (count @lst)))
+      (is (= #{"josh" "lop" "vadas"} (set names))))))
 
 
 

--- a/test/ogre/transform/order_test.clj
+++ b/test/ogre/transform/order_test.clj
@@ -10,13 +10,13 @@
                          (q/property :name)
                          q/order
                          q/into-vec!)]
-      (is ["josh" "lop" "marko""peter" "ripple" "vadas"] names)))
+      (is (= ["josh" "lop" "marko""peter" "ripple" "vadas"] names))))
   (testing "g(g.getVertices).property('name').order(ab)"
     (let [names (q/query (g/get-vertices)
                          (q/property :name)
                          (q/order #(compare %2 %1))
                          q/into-vec!)]
-      (is ["vadas""ripple""peter" "marko" "lop" "josh"] names)))
+      (is (= ["vadas""ripple""peter" "marko" "lop" "josh"] names))))
 
   (testing "g(g.getVertices).order(a.name>b.name).property('name')"
     (let [names (q/query (g/get-vertices)
@@ -25,11 +25,11 @@
                                              (g/get-property :name b))))
                          (q/property :name)
                          q/into-vec!)]
-      (is ["vadas""ripple""peter" "marko" "lop" "josh"] names)))
+      (is (= ["vadas""ripple""peter" "marko" "lop" "josh"] names))))
 
   (testing "g(g.getVertices).property('name').order(decr)"
     (let [names (q/query (g/get-vertices)
                          (q/property :name)
                          q/reverse
                          q/into-vec!)]
-      (is ["vadas""ripple""peter" "marko" "lop" "josh"] names))))
+      (is (= ["vadas""ripple""peter" "marko" "lop" "josh"] names)))))

--- a/test/ogre/transform/traversal_test.clj
+++ b/test/ogre/transform/traversal_test.clj
@@ -13,22 +13,22 @@
     (let [vs (q/query (g/find-by-id 1)
                       q/-->
                       q/into-vec!)]
-      (is (= #{"vadas" "josh" "lop"})
-          (u/get-names-set vs))))
+      (is (= #{"vadas" "josh" "lop"}
+             (u/get-names-set vs)))))
   
   (testing "test_g_v2_in()"
     (let [vs (q/query (g/find-by-id 2)
                       q/<--
                       q/into-vec!)]
-      (is (= #{"marko"})
-          (u/get-names-set vs))))
+      (is (= #{"marko"}
+             (u/get-names-set vs)))))
   
   (testing "test_g_v4_both()"
     (let [vs (q/query (g/find-by-id 2)
                       q/<->
                       q/into-vec!)]
-      (is (= #{"marko" "ripple" "lop"})
-          (u/get-names-set vs))))
+      (is (= #{"marko" "ripple" "lop"}
+             (u/get-names-set vs)))))
   
   (testing "test_g_E"
     "Nothign to see here")
@@ -62,54 +62,54 @@
                       q/-E>
                       q/in-vertex
                       q/into-vec!)]
-      (is (= #{"vadas" "josh" "lop"})
-          (u/get-names-set vs))))
+      (is (= #{"vadas" "josh" "lop"}
+             (u/get-names-set vs)))))
 
   (testing "test_g_v2_inE_outV"
     (let [vs (q/query (g/find-by-id 2)
                       q/<E-
                       q/out-vertex
                       q/into-vec!)]
-      (is (= #{"vadas" "josh" "lop"})
-          (u/get-names-set vs))))
+      (is (= #{"vadas" "josh" "lop"}
+             (u/get-names-set vs)))))
 
   (testing "test_g_v1_out(knows)"
     (let [vs (q/query (g/find-by-id 1)
                       (q/--> [:knows])
                       q/into-vec!)]
-      (is (= #{"vadas" "josh"})
-          (u/get-names-set vs))))
+      (is (= #{"vadas" "josh"}
+             (u/get-names-set vs)))))
 
   (testing "test_g_v1_out(knows created)"
     (let [vs (q/query (g/find-by-id 1)
                       (q/--> [:knows :created])
                       q/into-vec!)]
-      (is (= #{"vadas" "josh"})
-          (u/get-names-set vs))))
+      (is (= #{"vadas" "josh"}
+             (u/get-names-set vs)))))
   
   (testing "test_g_v1_outE(knows)_inV"
     (let [vs (q/query (g/find-by-id 1)
                       (q/-E> [:knows])
                       q/in-vertex
                       q/into-vec!)]
-      (is (= #{"vadas" "josh"})
-          (u/get-names-set vs))))
+      (is (= #{"vadas" "josh"}
+             (u/get-names-set vs)))))
 
   (testing "test_g_v1_outE(knows created)_inE"
     (let [vs (q/query (g/find-by-id 1)
                       (q/-E> [:knows :created])
                       q/in-vertex
                       q/into-vec!)]
-      (is (= #{"vadas" "josh"})
-          (u/get-names-set vs))))
+      (is (= #{"vadas" "josh"}
+             (u/get-names-set vs)))))
 
   (testing "test_g_v1_out_out"
     (let [vs (q/query (g/find-by-id 1)
                       q/-->
                       q/-->
                       q/into-vec!)]
-      (is (= #{"ripple" "lop"})
-          (u/get-names-set vs))))
+      (is (= #{"ripple" "lop"}
+             (u/get-names-set vs)))))
 
   (testing "test_g_v1_out_out_out"
     (let [vs (q/query (g/find-by-id 1)


### PR DESCRIPTION
There were several (= x y) expressions changed to (is (= x y)).  They
had no is, and thus could never cause tests to fail.

Changed several occurrences of (is expr1 expr2) to (is (= expr1
expr2)).  When expr1 evaluates to a value that is neither false nor
nil, the former kind of 'test' always passes.

Similarly for occurrences of (is (= expr1) expr2).  (= expr1) is
always true, so the test always passes.

Found using a pre-release version of the Eastwood Clojure lint tool.

I apologize for not knowing enough about ogre to fix the tests that
now do not pass.  I was hoping an ogre developer could look into
those, now that they can see which ones are failing.
