### PR TITLE
use doseq instead of map to clear *graph* in use-clean-graph!

### DIFF
--- a/src/ogre/tinkergraph.clj
+++ b/src/ogre/tinkergraph.clj
@@ -14,8 +14,10 @@
 
 (defn use-clean-graph! []
   (use-new-tinker-graph!)
-  (map #(.removeEdge *graph* %) (seq (.getEdges *graph*)))
-  (map #(.removeVertex *graph* %) (seq (.getVertices *graph*))))
+  (doseq [edge (.getEdges *graph*)]
+    (.removeEdge *graph* edge))
+  (doseq [vertex (.getVertices *graph*)]
+    (.removeVertex *graph* vertex)))
 
 ;;Element mutation
 


### PR DESCRIPTION
Since map is lazy, it's not guaranteed that those calls will ever be evaluated.
Found using eastwood.
