### PR TITLE
Change transactional graph test implementation to neo4j

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,11 +10,9 @@
                  [com.tinkerpop/pipes "2.5.0"]]
   :source-paths ["src/clojure"]
   :profiles {:dev    { :global-vars {*assert* true}
-                       :dependencies [[com.thinkaurelius.titan/titan-core  "0.5.0"]
-                                     [com.thinkaurelius.titan/titan-berkeleyje "0.5.0"]
+                       :dependencies [[com.tinkerpop.blueprints/blueprints-neo4j-graph "2.5.0"]
                                      [org.slf4j/slf4j-nop "1.7.5"]
-                                     [clojurewerkz/support "1.0.0" :exclusions [com.google.guava/guava
-                                                                                org.clojure/clojure]]
+                                     [clojurewerkz/support "1.0.0" :exclusions [org.clojure/clojure]]
                                      [commons-io/commons-io "2.4"]]}
              :1.4    {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.6    {:dependencies [[org.clojure/clojure "1.6.0"]]}


### PR DESCRIPTION
The titan API will always lag behind tinkerpop releases.  neo4j is considered the "official" transactional implementation for tinkerpop, so it is best to use neo4j and not have titan as a dependency.  neo4j does not support threaded transactions, so those tests have been removed.
