### PR TITLE
Added contains? operator for has predicate.

### DIFF
--- a/src/clojure/clojurewerkz/ogre/util.clj
+++ b/src/clojure/clojurewerkz/ogre/util.clj
@@ -1,7 +1,7 @@
 (ns clojurewerkz.ogre.util
   (:import (com.tinkerpop.gremlin.process Traversal)
            (com.tinkerpop.gremlin.process.graph GraphTraversal VertexTraversal EdgeTraversal)
-           (com.tinkerpop.gremlin.structure Compare Direction)
+           (com.tinkerpop.gremlin.structure Compare Direction Contains)
            (java.util.function Function Consumer Predicate BiFunction)))
 
 (defmacro typed-traversal
@@ -33,7 +33,8 @@
     >=   Compare/gte
     >    Compare/gt
     <=   Compare/lte
-    <    Compare/lt))
+    <    Compare/lt
+    contains? Contains/within))
 
 (defn ^"[Ljava.lang.String;" str-array [strs]
   "Converts a collection of strings to a java String array."

--- a/test/clojurewerkz/ogre/filter/has_test.clj
+++ b/test/clojurewerkz/ogre/filter/has_test.clj
@@ -44,4 +44,12 @@
                       (q/has :age > (int 30))
                       q/into-vec!)]
       (is (= 2 (count vs)))
-      (is (every? (partial < 30) (u/get-ages vs))))))
+      (is (every? (partial < 30) (u/get-ages vs)))))
+
+  (testing "g.V().has('location',Contains.within,['aachen', 'san diego', 'brussels'])"
+    (let [g (u/crew-tinkergraph)
+          vs (q/query (v/get-all-vertices g)
+                      (q/has :location contains? ["aachen" "san diego" "brussels"])
+                      q/into-vec!)]
+      (is (= 2 (count vs)))
+      (is (every? (partial some #{"aachen" "san diego"}) (u/get-locations vs))))))

--- a/test/clojurewerkz/ogre/test_util.clj
+++ b/test/clojurewerkz/ogre/test_util.clj
@@ -14,6 +14,10 @@
   "Returns a map of ages of the given vertices."
   (map #(el/get % :age) vs))
 
+(defn get-locations [vs]
+  "Returns a map of locations of the given vertices."
+  (map #(el/get % :location) vs))
+
 (defn get-ages-set [vs]
   "Returns a set of ages of the given vertices."
   (set (get-ages vs)))


### PR DESCRIPTION
has predicate is lacking within operator for testing inclusion in a list. This patch adds this operator and accompanying tests.  

Potential pitfalls:
* Clojure doesn't have a direct translation for (with)in operator. I opted for contains? which to me is semantically closest (even though it's an idiosyncrasy in clj-land). I felt usage should be consistent, ie. all operators should symbols and be from the same namespace. A slight (semantic) issue with contains? is, it doesn't have an inverse as is the case in the original.
* I added an accessor for location property to test_util.clj. Not sure if this is correct for a single test.