### PR TITLE
Reflection

### DIFF
--- a/src/clojure/clojurewerkz/ogre/core.clj
+++ b/src/clojure/clojurewerkz/ogre/core.clj
@@ -1,7 +1,7 @@
 (ns clojurewerkz.ogre.core
   (:refer-clojure :exclude [filter and or range count iterate next map loop reverse])
   (:require [potemkin :as po]
-            [clojurewerkz.ogre.util :as util :refer (keywords-to-str-array)]
+            [clojurewerkz.ogre.util :as util :refer (keywords-to-str-array typed-traversal)]
             [clojurewerkz.ogre.filter :as filter]
             [clojurewerkz.ogre.map :as map]
             [clojurewerkz.ogre.traversal :as traversal]
@@ -22,19 +22,20 @@
                ;;       " direction and returns the vertices.")
                ([t#] (~direction t# []))
                ([t# labels#]
-                 (-> t# (~j1 (keywords-to-str-array labels#)))))
+                (typed-traversal ~j1 t# (keywords-to-str-array labels#))))
              (defn ~short
                [& args#]
                (apply ~direction args#))
              (defn ~f1
                ([t#] (~f1 t# []))
                ([t# labels#]
-                  (-> t# (~j2 (keywords-to-str-array labels#)))))
+                (typed-traversal ~j2 t# (keywords-to-str-array labels#))))
              (defn ~shortE
                [& args#]
                (apply ~f1 args#))
-             (defn ~name1 [t#]
-               (-> t# (~j3)))))))
+             (defn ~name1
+               [t#]
+               (typed-traversal ~j3 t#))))))
 
 ;; clojurewerkz.ogre.util
 (po/import-fn util/as)
@@ -46,7 +47,7 @@
 (po/import-fn filter/dedup)
 (po/import-fn filter/except)
 (po/import-fn filter/filter)
-(po/import-macro filter/has)
+(po/import-fn filter/has)
 (po/import-fn filter/has-not)
 (po/import-fn filter/interval)
 (po/import-fn filter/limit)

--- a/src/clojure/clojurewerkz/ogre/filter.clj
+++ b/src/clojure/clojurewerkz/ogre/filter.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [filter and or range])
   (:import (com.tinkerpop.gremlin.process Traversal)
            (java.util Collection))
-  (:require [clojurewerkz.ogre.util :refer (convert-symbol-to-compare f-to-function f-to-predicate typed-traversal)]))
+  (:require [clojurewerkz.ogre.util :refer (f-to-function f-to-predicate typed-traversal f-to-bipredicate)]))
 
 (defn cyclic-path
   "The step analyzes the path of the traverser thus far and if there are any repeats, the traverser
@@ -30,15 +30,15 @@
   "Filters using a predicate that determines whether an object should pass."
   [^Traversal t f] (typed-traversal .filter t (f-to-predicate f)))
 
-(defmacro has
+(defn has
   "Allows an element if it has the given property. Supports the standard
   clojure symbolic comparison operators."
   ([^Traversal t k]
-    `(.has ~t ~(name k)))
+    (typed-traversal .has t (name k)))
   ([^Traversal t k v]
-    `(.has ~t ~(name k) ~v))
+    (typed-traversal .has t (name k) v))
   ([^Traversal t k c v]
-    `(.has ~t ~(name k) (convert-symbol-to-compare '~c) ~v)))
+    (typed-traversal .has t (name k) (f-to-bipredicate c) v)))
 
 (defn has-not
   "Allows an element if it does not the given property."

--- a/src/clojure/clojurewerkz/ogre/filter.clj
+++ b/src/clojure/clojurewerkz/ogre/filter.clj
@@ -31,17 +31,16 @@
   [^Traversal t f] (typed-traversal .filter t (f-to-predicate f)))
 
 (defn has
-  "Allows an element if it has the given property. Supports the standard
-  clojure symbolic comparison operators."
+  "Allows an element if it has the given property or it satisfies given predicate."
   ([^Traversal t k]
     (typed-traversal .has t (name k)))
   ([^Traversal t k v]
     (typed-traversal .has t (name k) v))
-  ([^Traversal t k c v]
-    (typed-traversal .has t (name k) (f-to-bipredicate c) v)))
+  ([^Traversal t k pred v]
+    (typed-traversal .has t (name k) (f-to-bipredicate pred) v)))
 
 (defn has-not
-  "Allows an element if it does not the given property."
+  "Allows an element if it does not have the given property."
   ([^Traversal t k]
     (typed-traversal .hasNot t (name k))))
 

--- a/src/clojure/clojurewerkz/ogre/io.clj
+++ b/src/clojure/clojurewerkz/ogre/io.clj
@@ -23,7 +23,7 @@
   (if-not (nil? arg) (setter builder arg) builder))
 
 ;; GraphML Reader
-(defn make-graphml-reader [& {:keys [vertex-id-key edge-id-key edge-label-key vertex-label-key batch-size]}]
+(defn ^GraphMLReader make-graphml-reader [& {:keys [vertex-id-key edge-id-key edge-label-key vertex-label-key batch-size]}]
   (let [builder (GraphMLReader/build)]
     (-> builder
       (set-if-present vertex-id-key (memfn vertexIdKey))
@@ -35,7 +35,7 @@
 (def read-graph-graphml (partial read-graph-with-reader #(.readGraph (make-graphml-reader) %1 %2)))
 
 ;; GraphML Writer
-(defn make-graphml-writer [& {:keys [normalize vertex-key-types edge-key-types edge-label-key vertex-label-key xml-schema-location]}]
+(defn ^GraphMLWriter make-graphml-writer [& {:keys [normalize vertex-key-types edge-key-types edge-label-key vertex-label-key xml-schema-location]}]
   (let [builder (GraphMLWriter/build)]
     (-> builder
       (set-if-present normalize (memfn normalize))
@@ -48,7 +48,7 @@
 (def write-graph-graphml (partial write-graph-with-writer #(.writeGraph (make-graphml-writer) %1 %2)))
 
 ;; GraphSON Reader
-(defn make-graphson-reader [& {:keys [vertex-id-key edge-id-key custom-module load-custom-modules embed-types batch-size]}]
+(defn ^GraphSONReader make-graphson-reader [& {:keys [vertex-id-key edge-id-key custom-module load-custom-modules embed-types batch-size]}]
   (let [builder (GraphSONReader/build)]
     (-> builder
       (set-if-present vertex-id-key (memfn vertexIdKey))
@@ -61,7 +61,7 @@
 (def read-graph-graphson (partial read-graph-with-reader #(.readGraph (make-graphson-reader) %1 %2)))
 
 ;; GraphSON Writer
-(defn make-graphson-writer [& {:keys [custom-module load-custom-modules embed-types normalize]}]
+(defn ^GraphSONWriter make-graphson-writer [& {:keys [custom-module load-custom-modules embed-types normalize]}]
   (let [builder (GraphSONWriter/build)]
     (-> builder
       (set-if-present normalize (memfn normalize))
@@ -72,7 +72,7 @@
 (def write-graph-graphson (partial write-graph-with-writer #(.writeGraph (make-graphson-writer) %1 %2)))
 
 ;; Kryo Reader
-(defn make-kryo-reader [& {:keys [vertex-id-key edge-id-key working-directory custom batch-size]}]
+(defn ^KryoReader make-kryo-reader [& {:keys [vertex-id-key edge-id-key working-directory custom batch-size]}]
   (let [builder (KryoReader/build)]
     (-> builder
       (set-if-present vertex-id-key (memfn vertexIdKey))
@@ -84,7 +84,7 @@
 (def read-graph-kryo (partial read-graph-with-reader #(.readGraph (make-kryo-reader) %1 %2)))
 
 ;; Kryo Writer
-(defn make-kryo-writer [& {:keys [custom]}]
+(defn ^KryoWriter make-kryo-writer [& {:keys [custom]}]
   (let [builder (KryoWriter/build)]
     (-> builder
       (set-if-present custom (memfn custom))

--- a/src/clojure/clojurewerkz/ogre/map.clj
+++ b/src/clojure/clojurewerkz/ogre/map.clj
@@ -29,7 +29,7 @@
 
 (defn label
   "Gets the label of an element."
-  ([^Traversal t] (typed-traversal .label t)))
+  ([^GraphTraversal t] (.label t)))
 
 (defn map
   "Gets the property map of an element."

--- a/src/clojure/clojurewerkz/ogre/traversal.clj
+++ b/src/clojure/clojurewerkz/ogre/traversal.clj
@@ -1,7 +1,7 @@
 (ns clojurewerkz.ogre.traversal
   (:refer-clojure :exclude [iterate])
   (:import (com.tinkerpop.gremlin.process Traversal))
-  (:require [clojurewerkz.ogre.util :refer (convert-to-map)]))
+  (:require [clojurewerkz.ogre.util :refer (convert-to-map typed-traversal)]))
 
 (defn iterate!
   "Iterates the traversal."
@@ -80,5 +80,4 @@
 (defn count!
   "Returns the number of objects currently in the traversal."
   [^Traversal t]
-  (next! (.count t)))
-
+  (next! (typed-traversal .count t)))

--- a/src/clojure/clojurewerkz/ogre/util.clj
+++ b/src/clojure/clojurewerkz/ogre/util.clj
@@ -2,7 +2,7 @@
   (:import (com.tinkerpop.gremlin.process Traversal)
            (com.tinkerpop.gremlin.process.graph GraphTraversal VertexTraversal EdgeTraversal)
            (com.tinkerpop.gremlin.structure Compare Direction Contains)
-           (java.util.function Function Consumer Predicate BiFunction)))
+           (java.util.function Function Consumer Predicate BiPredicate BiFunction)))
 
 (defmacro typed-traversal
   [method ^Traversal t & args]
@@ -24,17 +24,6 @@
   "Starts a subquery."
   [& body]
   `(-> ~@body))
-
-(defn ^Compare convert-symbol-to-compare [s]
-  "Converts a symbolic comparison operator to a Gremlin structure comparison enumeration."
-  (case s
-    =    Compare/eq
-    not= Compare/neq
-    >=   Compare/gte
-    >    Compare/gt
-    <=   Compare/lte
-    <    Compare/lt
-    contains? Contains/within))
 
 (defn ^"[Ljava.lang.String;" str-array [strs]
   "Converts a collection of strings to a java String array."
@@ -83,6 +72,11 @@
   "Converts a function to java.util.function.Predicate."
   (reify Predicate
     (test [this arg] (f arg))))
+
+(defn ^BiPredicate f-to-bipredicate [f]
+  "Converts a function to java.util.function.BiPredicate."
+  (reify BiPredicate
+    (test [this a b] (f a b))))
 
 (defprotocol EdgeDirectionConversion
   (to-edge-direction [input] "Converts input to a Gremlin structure edge direction"))

--- a/test/clojurewerkz/ogre/filter/has_test.clj
+++ b/test/clojurewerkz/ogre/filter/has_test.clj
@@ -49,7 +49,7 @@
   (testing "g.V().has('location',Contains.within,['aachen', 'san diego', 'brussels'])"
     (let [g (u/crew-tinkergraph)
           vs (q/query (v/get-all-vertices g)
-                      (q/has :location contains? ["aachen" "san diego" "brussels"])
+                      (q/has :location "aachen")
                       q/into-vec!)]
-      (is (= 2 (count vs)))
-      (is (every? (partial some #{"aachen" "san diego"}) (u/get-locations vs))))))
+      (is (= 1 (count vs)))
+      (is (every? (partial some #{"aachen"}) (u/get-locations vs))))))

--- a/test/clojurewerkz/ogre/graph_test.clj
+++ b/test/clojurewerkz/ogre/graph_test.clj
@@ -19,7 +19,7 @@
         (try
           (f)
           (finally
-            (.close *graph*))))
+            (.close ^Neo4jGraph *graph*))))
       (finally
         (FileUtils/deleteQuietly tmp)))))
 

--- a/test/clojurewerkz/ogre/map/map_test.clj
+++ b/test/clojurewerkz/ogre/map/map_test.clj
@@ -1,5 +1,6 @@
 (ns clojurewerkz.ogre.map.map-test
   (:use [clojure.test])
+  (:import (com.tinkerpop.gremlin.process Traverser))
   (:require [clojurewerkz.ogre.core :as q]
             [clojurewerkz.ogre.vertex :as v]
             [clojurewerkz.ogre.test-util :as u]))
@@ -15,7 +16,7 @@
     (let [names (q/query (v/find-by-id (u/classic-tinkergraph) (int 1))
                          q/-E>
                          q/label
-                         (q/map #(count (.get %)))
+                         (q/map #(count (.get ^Traverser %)))
                          q/into-vec!)]
       (is (= (set (map count ["knows" "created"]))
              (set names)))
@@ -25,7 +26,7 @@
     (let [names (q/query (v/find-by-id (u/classic-tinkergraph) (int 1))
                          q/-->
                          (q/map #(v/get % :name))
-                         (q/map #(count (.get %)))
+                         (q/map #(count (.get ^Traverser %)))
                          q/into-vec!)]
       (is (= (set (map count ["josh" "vadas" "lop"]))
              (set names)))

--- a/test/clojurewerkz/ogre/map/path_test.clj
+++ b/test/clojurewerkz/ogre/map/path_test.clj
@@ -1,5 +1,6 @@
 (ns clojurewerkz.ogre.map.path-test
   (:use [clojure.test])
+  (:import (com.tinkerpop.gremlin.process Path))
   (:require [clojurewerkz.ogre.core :as q]
             [clojurewerkz.ogre.vertex :as v]
             [clojurewerkz.ogre.test-util :as u]))
@@ -7,9 +8,10 @@
 (deftest test-path-step
   (testing "g.v(1).values('name').path().next()"
     (let [g (u/classic-tinkergraph)
-          path (.objects (q/query (v/find-by-id g (int 1))
-                                  (q/values :name)
-                                  q/path
-                                  q/next!))]
+          path (q/query (v/find-by-id g (int 1))
+                        (q/values :name)
+                        q/path
+                        q/next!)
+          path (.objects ^Path path)]
       (is (= "marko" (v/get (first path) :name)))
       (is (= "marko" (second path))))))

--- a/test/clojurewerkz/ogre/side_effect/side_effect_test.clj
+++ b/test/clojurewerkz/ogre/side_effect/side_effect_test.clj
@@ -1,5 +1,6 @@
 (ns clojurewerkz.ogre.side-effect.side-effect-test
   (:use [clojure.test])
+  (:import (com.tinkerpop.gremlin.process Traverser))
   (:require [clojurewerkz.ogre.core :as q]
             [clojurewerkz.ogre.vertex :as v]
             [clojurewerkz.ogre.test-util :as u]))
@@ -13,7 +14,7 @@
                       (q/side-effect (partial swap! lst conj))
                       (q/values :name)
                       q/into-vec!)]
-      (is (= elem (.get (first @lst))))
+      (is (= elem (.get ^Traverser (first @lst))))
       (is (= "marko" (first names)))))
 
   (testing "g.v(1).out().sideEffect{lst.add(it)}.values('name')"
@@ -27,9 +28,3 @@
                       q/into-vec!)]
       (is (= 3 (count @lst)))
       (is (= #{"josh" "lop" "vadas"} (set names))))))
-
-
-
-
-
-


### PR DESCRIPTION
Most of it is banal, the only major change is has where I changed has from macro to fn and removed convert-symbol-to-compare functionality in favour of a more general casting to BiPredicate (this also makes my previous contribution adding contains?/within operator obsolete, see has_test.clj).