### PR TITLE
Support keywords for named steps (as, select, back).

### DIFF
--- a/src/clojure/clojurewerkz/ogre/map.clj
+++ b/src/clojure/clojurewerkz/ogre/map.clj
@@ -3,11 +3,11 @@
   (:import (com.tinkerpop.gremlin.process Traversal)
            (com.tinkerpop.gremlin.process.graph GraphTraversal)
            (com.tinkerpop.gremlin.structure Order))
-  (:require [clojurewerkz.ogre.util :refer (f-to-function fs-to-function-array keywords-to-str-array f-to-bifunction typed-traversal)]))
+  (:require [clojurewerkz.ogre.util :refer (f-to-function fs-to-function-array keywords-to-str-array keywords-to-str-list f-to-bifunction typed-traversal)]))
 
 (defn back
   "Goes back to the results of a named step."
-  ([^Traversal t step-label] (typed-traversal .back t step-label)))
+  ([^Traversal t step-label] (typed-traversal .back t (name step-label))))
 
 ;; flatMap
 ;; fold(BiFunction)
@@ -73,9 +73,9 @@
 (defn select-only
   "Select the named steps to emit, with optional functions for post processing round robin style."
   ([^Traversal t cols]
-    (select-only t cols identity))
-  ([^Traversal t ^java.util.List cols & fs]
-    (typed-traversal .select t cols (fs-to-function-array fs))))
+   (select-only t cols identity))
+  ([^Traversal t cols & fs]
+   (typed-traversal .select t (keywords-to-str-list cols) (fs-to-function-array fs))))
 
 ;; shuffle
 ;; to

--- a/src/clojure/clojurewerkz/ogre/util.clj
+++ b/src/clojure/clojurewerkz/ogre/util.clj
@@ -14,8 +14,8 @@
 
 (defn as
   "Assigns a name to the previous step in a traversal."
-  [^Traversal t ^String label]
-  (typed-traversal .as t label))
+  [^Traversal t label]
+  (typed-traversal .as t ^String (name label)))
 
 (defmacro query
   "Starts a query."
@@ -38,6 +38,10 @@
 (defn keywords-to-str-array [strs]
   "Converts a collection of keywords to a java String array."
   (str-array (map name strs)))
+
+(defn ^java.util.ArrayList keywords-to-str-list [strs]
+  "Converts a collection of keywords to a java List of Strings."
+  (java.util.ArrayList. ^java.util.Collection  (mapv name strs)))
 
 (defn prop-map-to-array [m]
   "Converts a property map to a java Object array."

--- a/test/clojurewerkz/ogre/map/back_test.clj
+++ b/test/clojurewerkz/ogre/map/back_test.clj
@@ -1,6 +1,6 @@
 (ns clojurewerkz.ogre.map.back-test
-  (:use [clojure.test])
-  (:require [clojurewerkz.ogre.core :as q]
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojurewerkz.ogre.core :as q]
             [clojurewerkz.ogre.vertex :as v]
             [clojurewerkz.ogre.test-util :as u]))
 
@@ -8,9 +8,9 @@
   (testing "g.v(1).as('here').out().back('here')"
     (let [g (u/classic-tinkergraph)
           vs (q/query (v/find-by-id g (int 1))
-                      (q/as "here")
+                      (q/as :here)
                       q/-->
-                      (q/back "here")
+                      (q/back :here)
                       q/into-vec!)]
       (is (= #{"marko"} (u/get-names-set vs)))
       (is (= 3 (count vs)))))
@@ -19,9 +19,9 @@
     (let [g (u/classic-tinkergraph)
           vs (q/query (v/find-by-id g (int 4))
                       q/-->
-                      (q/as "here")
+                      (q/as :here)
                       (q/filter #(= "java" (v/get % :lang)))
-                      (q/back "here")
+                      (q/back :here)
                       q/into-vec!)]
       (is (= #{"ripple" "lop"} (u/get-names-set vs)))
       (is (= 2 (count vs)))))
@@ -30,9 +30,9 @@
     (let [g (u/classic-tinkergraph)
           names (q/query (v/find-by-id g (int 4))
                          q/-->
-                         (q/as "here")
+                         (q/as :here)
                          (q/filter #(= "java" (v/get % :lang)))
-                         (q/back "here")
+                         (q/back :here)
                          (q/values :name)
                          q/into-set!)]
       (is (= #{"ripple" "lop"} names))

--- a/test/clojurewerkz/ogre/map/select_test.clj
+++ b/test/clojurewerkz/ogre/map/select_test.clj
@@ -1,6 +1,6 @@
 (ns clojurewerkz.ogre.map.select-test
-  (:use [clojure.test])
-  (:require [clojurewerkz.ogre.core :as q]
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojurewerkz.ogre.core :as q]
             [clojurewerkz.ogre.vertex :as v]
             [clojurewerkz.ogre.test-util :as u]))
 
@@ -8,9 +8,9 @@
   (testing "g.v(1).as('a').out('knows').as('b').select()"
     (let [g (u/classic-tinkergraph)
            selection (q/query (v/find-by-id g (int 1))
-                             (q/as "a")
+                             (q/as :a)
                              (q/--> [:knows])
-                             (q/as "b")
+                             (q/as :b)
                              q/select
                              q/all-into-vecs!)]
       ;;TODO turn these into maps in core
@@ -22,9 +22,9 @@
   (testing "g.v(1).as('a').out('knows').as('b').select{it.value('name')}"
     (let [g (u/classic-tinkergraph)
           selection (q/query (v/find-by-id g (int 1))
-                             (q/as "a")
+                             (q/as :a)
                              (q/--> [:knows])
-                             (q/as "b")
+                             (q/as :b)
                              (q/select #(v/get % :name))
                              q/all-into-vecs!)]
       (is (= #{"marko"} (set (map val (map first selection)))))
@@ -35,10 +35,10 @@
   (testing "g.v(1).as('a').out('knows').as('b').select('a')"
     (let [g (u/classic-tinkergraph)
           selection (q/query (v/find-by-id g (int 1))
-                             (q/as "a")
+                             (q/as :a)
                              (q/--> [:knows])
-                             (q/as "b")
-                             (q/select-only ["a"])
+                             (q/as :b)
+                             (q/select-only [:a])
                              q/all-into-vecs!)]
       (is (= 2 (count selection)))
       (is (= 1 (count (first selection))))
@@ -47,10 +47,10 @@
   (testing "g.v(1).as('a').out('knows').as('b').select('a', {it.value('name')})"
     (let [g (u/classic-tinkergraph)
           selection (q/query (v/find-by-id g (int 1))
-                             (q/as "a")
+                             (q/as :a)
                              (q/--> [:knows])
-                             (q/as "b")
-                             (q/select-only ["a"] #(v/get % :name))
+                             (q/as :b)
+                             (q/select-only [:a] #(v/get % :name))
                              q/all-into-vecs!)]
       (is (= 2 (count selection)))
       (is (= 1 (count (first selection))))


### PR DESCRIPTION
Retains backwards compatibility with string names.