### PR TITLE
add log4j config file to provide logging for tests, see #85

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -25,6 +25,7 @@
                                        :releases {:checksum :fail :update :always}}}
   :plugins [[lein-junit "1.1.8"]]
   :java-source-paths ["test/java"]
+  :resource-paths ["test/resources"]
   :junit ["test/java"]
   :test-paths ["test/clojure"]
   :global-vars {*warn-on-reflection* true

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,9 @@
   :source-paths ["src/clojure"]
   :profiles {:dev    { :global-vars {*assert* true}
                        :dependencies [[clojurewerkz/support "1.1.0" :exclusions [org.clojure/clojure]]
-                                      [commons-io/commons-io "2.4"]]}
+                                      [commons-io/commons-io "2.4"]]
+                      :java-source-paths ["test/java"]
+                      :resource-paths ["test/resources"]}
              :1.5    {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.7    {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :master {:dependencies [[org.clojure/clojure "1.8.0-master-SNAPSHOT"]]}}
@@ -24,8 +26,6 @@
                                        :snapshots true
                                        :releases {:checksum :fail :update :always}}}
   :plugins [[lein-junit "1.1.8"]]
-  :java-source-paths ["test/java"]
-  :resource-paths ["test/resources"]
   :junit ["test/java"]
   :test-paths ["test/clojure"]
   :global-vars {*warn-on-reflection* true

--- a/test/resources/log4j.properties
+++ b/test/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=DEBUG, console
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
We should probably add a dev/test profile to exclude this (and the java test files) from the final jar, but this at least fixes the logging for now #85 