### PR TITLE
Don't require that TinkerGraph be made available

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ With Maven:
 
 ## Documentation & Examples
 
+You'll need to choose an implementation for the graph database and add that to your project's dependencies. Here we use the in-memory graph database implementation provided by `org.apache.tinkerpop/tinkergraph-gremlin`:
+
 ```text
-clojurewerkz.ogre.core=> (def graph (open-graph))
+clojurewerkz.ogre.core=> (def graph (open-graph {(Graph/GRAPH) (.getName org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph)}))
 #'clojurewerkz.ogre.core/graph
 clojurewerkz.ogre.core=> (def g (traversal graph))
 #'clojurewerkz.ogre.core/g

--- a/src/clojure/clojurewerkz/ogre/core.clj
+++ b/src/clojure/clojurewerkz/ogre/core.clj
@@ -23,7 +23,6 @@
 (defn open-graph
   "Opens a new TinkerGraph with default configuration or open a new Graph instance with the specified
    configuration. The configuration may be a path to a file or a Map of configuration options."
-  ([] (open-graph {(Graph/GRAPH) (.getName org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerGraph)}))
   ([conf]
    (cond
      (map? conf)


### PR DESCRIPTION
The no-argument version of clojurewerkz.ogre.core/open-graph relied upon
the TinkerGraph database implementation being available. This patch
removes that dependency and explains to users that they will need to
provide one.