### PR TITLE
Revert "patch to force the id type to be an integer"

### DIFF
--- a/src/clojure/clojurewerkz/ogre/core.clj
+++ b/src/clojure/clojurewerkz/ogre/core.clj
@@ -54,7 +54,7 @@
 (defn V
   "Returns all vertices matching the supplied ids. If no ids are supplied, returns all vertices."
   [^GraphTraversalSource g & ids]
-  (.V g (into-array (clojure.core/map int ids))))
+  (.V g (into-array ids)))
 
 (defn with-bulk
   [^GraphTraversalSource g use-bulk]


### PR DESCRIPTION
Reverts clojurewerkz/ogre#92
There is an upstream fix to TinkerFactory/createModern coming so this should be backed out.