### PR TITLE
Remove erroneous line in change log.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,7 +25,6 @@ revised API.
  * Bump to support of TinkerPop 2.5.0.
  * Arity 2 `has` and `has-not` filters.
  * Add `into-list!` function.
- * Potemkin dependency is dropped.
 
 ## Changes in Ogre 2.3.0.2
 


### PR DESCRIPTION
This "change" about 2.5.0.0 was added to the change log after the 2.5.0.0 tag, and potemkin is still a dependency of the project.

This came up in a project where we were diagnosing an elusive bug integrating clj-http and ogre, which turned out to be related to potemkin features. (If we have more detail, we'll open new issues.)