### PR TITLE
Common api for GraphTraversal and GraphTraversalSource

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -18,10 +18,10 @@
                                       [commons-io/commons-io "2.4"]]}
              :master { :dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}}
   :aliases {"all" ["with-profile" "dev,dev:master"]}
-  :repositories {"sonatype" {:url "http://oss.sonatype.org/content/repositories/releases"
+  :repositories {"sonatype" {:url "https://oss.sonatype.org/content/repositories/releases"
                              :snapshots false
                              :releases {:checksum :fail :update :always}}
-                 "sonatype-snapshots" {:url "http://oss.sonatype.org/content/repositories/snapshots"
+                 "sonatype-snapshots" {:url "https://oss.sonatype.org/content/repositories/snapshots"
                                        :snapshots true
                                        :releases {:checksum :fail :update :always}}}
   :plugins [[lein-junit "1.1.8"]]

--- a/src/clojure/clojurewerkz/ogre/anon.clj
+++ b/src/clojure/clojurewerkz/ogre/anon.clj
@@ -14,15 +14,19 @@
   [xs & body]
    `(-> (apply ~(symbol (str "clojurewerkz.ogre.anon/__" (name (first xs)))) ~(vec (rest xs))) ~@body))
 
-(defn __addE
+(defn __add-E
   [label]
   (org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__/addE ^String (util/cast-param label)))
 
-(defn __addV
+(def __addE __add-E)
+
+(defn __add-V
   ([]
    (org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__/addV))
   ([label]
    (org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__/addV ^String (util/cast-param label))))
+
+(def __addV __add-V)
 
 (defn __aggregate
   [k]
@@ -461,10 +465,11 @@
     (org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__/until ^Traversal pred-or-t)
     (org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__/until (util/f-to-predicate pred-or-t))))
 
-(defn __midV
-  "A mid-traversal V known in Gremlin-Java as just V()"
+(defn __V
   [& ids]
   (org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__/V (into-array ids)))
+
+(def __midV __V)
 
 (defn __value
   []

--- a/src/clojure/clojurewerkz/ogre/core.clj
+++ b/src/clojure/clojurewerkz/ogre/core.clj
@@ -37,7 +37,7 @@
 
 ; Common Functionality between GraphTraversalSource and GraphTraversal
 (defmulti add-V
-  "Adds a vertex to the traversal"
+  "Adds a vertex to the traversal."
   (fn
     ([g _] (class g))
     ([g] (class g))))
@@ -50,19 +50,9 @@
   ([^GraphTraversalSource g] (.addV g))
   ([^GraphTraversalSource g label] (.addV g ^String (util/cast-param label))))
 
-(defmulti addV
-  "Adds a vertex to the traversal"
-  (fn
-    ([g _] (class g))
-    ([g] (class g))))
-
-(defmethod addV GraphTraversal
-  ([^GraphTraversal g] (.addV g))
-  ([^GraphTraversal g label] (.addV g ^String (util/cast-param label))))
-
-(defmethod addV GraphTraversalSource
-  ([^GraphTraversalSource g] (.addV g))
-  ([^GraphTraversalSource g label] (.addV g ^String (util/cast-param label))))
+(def addV
+  "Adds a vertex to the traversal. `addV` is equivalent to `add-V`."
+  add-V)
 
 (defmulti add-E
   "Adds an edge to the traversal"
@@ -74,18 +64,12 @@
 (defmethod add-E GraphTraversalSource
   ([^GraphTraversalSource g label] (.addE g ^String (util/cast-param label))))
 
-(defmulti addE
-  "Adds an edge to the traversal"
-  (fn [g _] (class g)))
-
-(defmethod addE GraphTraversal
-  ([^GraphTraversal g label] (.addE g ^String (util/cast-param label))))
-
-(defmethod addE GraphTraversalSource
-  ([^GraphTraversalSource g label] (.addE g ^String (util/cast-param label))))
+(def addE
+  "Adds an edge to the traversal. `addE` is equivalent to `add-E`."
+  add-E)
 
 (defmulti V
-  "Returns all vertices matching the supplied ids. If no ids are supplied, returns all vertices"
+  "Returns all vertices matching the supplied ids. If no ids are supplied, returns all vertices."
   (fn [g & _] (class g)))
 
 (defmethod V GraphTraversal
@@ -96,17 +80,10 @@
   [^GraphTraversalSource g & ids]
   (.V g (into-array ids)))
 
-(defmulti midV
-  "Returns all vertices matching the supplied ids. If no ids are supplied, returns all vertices"
-  (fn [g & _] (class g)))
-
-(defmethod midV GraphTraversal
-  [^GraphTraversal g & ids]
-  (.V g (into-array ids)))
-
-(defmethod midV GraphTraversalSource
-  [^GraphTraversalSource g & ids]
-  (.V g (into-array ids)))
+(def midV
+  "Returns all vertices matching the supplied ids. If no ids are supplied, returns all vertices.
+  `midV` is equivalent to `V`"
+  V)
 
 ; GraphTraversalSource
 (defn E

--- a/src/clojure/clojurewerkz/ogre/core.clj
+++ b/src/clojure/clojurewerkz/ogre/core.clj
@@ -35,17 +35,80 @@
   [^Graph graph]
   (.traversal graph))
 
+; Common Functionality between GraphTraversalSource and GraphTraversal
+(defmulti add-V
+  "Adds a vertex to the traversal"
+  (fn
+    ([g _] (class g))
+    ([g] (class g))))
+
+(defmethod add-V GraphTraversal
+  ([^GraphTraversal g] (.addV g))
+  ([^GraphTraversal g label] (.addV g ^String (util/cast-param label))))
+
+(defmethod add-V GraphTraversalSource
+  ([^GraphTraversalSource g] (.addV g))
+  ([^GraphTraversalSource g label] (.addV g ^String (util/cast-param label))))
+
+(defmulti addV
+  "Adds a vertex to the traversal"
+  (fn
+    ([g _] (class g))
+    ([g] (class g))))
+
+(defmethod addV GraphTraversal
+  ([^GraphTraversal g] (.addV g))
+  ([^GraphTraversal g label] (.addV g ^String (util/cast-param label))))
+
+(defmethod addV GraphTraversalSource
+  ([^GraphTraversalSource g] (.addV g))
+  ([^GraphTraversalSource g label] (.addV g ^String (util/cast-param label))))
+
+(defmulti add-E
+  "Adds an edge to the traversal"
+  (fn [g _] (class g)))
+
+(defmethod add-E GraphTraversal
+  ([^GraphTraversal g label] (.addE g ^String (util/cast-param label))))
+
+(defmethod add-E GraphTraversalSource
+  ([^GraphTraversalSource g label] (.addE g ^String (util/cast-param label))))
+
+(defmulti addE
+  "Adds an edge to the traversal"
+  (fn [g _] (class g)))
+
+(defmethod addE GraphTraversal
+  ([^GraphTraversal g label] (.addE g ^String (util/cast-param label))))
+
+(defmethod addE GraphTraversalSource
+  ([^GraphTraversalSource g label] (.addE g ^String (util/cast-param label))))
+
+(defmulti V
+  "Returns all vertices matching the supplied ids. If no ids are supplied, returns all vertices"
+  (fn [g & _] (class g)))
+
+(defmethod V GraphTraversal
+  [^GraphTraversal g & ids]
+  (.V g (into-array ids)))
+
+(defmethod V GraphTraversalSource
+  [^GraphTraversalSource g & ids]
+  (.V g (into-array ids)))
+
+(defmulti midV
+  "Returns all vertices matching the supplied ids. If no ids are supplied, returns all vertices"
+  (fn [g & _] (class g)))
+
+(defmethod midV GraphTraversal
+  [^GraphTraversal g & ids]
+  (.V g (into-array ids)))
+
+(defmethod midV GraphTraversalSource
+  [^GraphTraversalSource g & ids]
+  (.V g (into-array ids)))
+
 ; GraphTraversalSource
-(defn add-V
-  ([^GraphTraversalSource g]
-    (.addV g))
-  ([^GraphTraversalSource g label]
-    (.addV g ^String (util/cast-param label))))
-
-(defn add-E
-  [^GraphTraversalSource g label]
-   (.addE g ^String (util/cast-param label)))
-
 (defn E
   "Returns all edges matching the supplied ids. If no ids are supplied, returns all edges."
   [^GraphTraversalSource g & ids]
@@ -54,11 +117,6 @@
 (defn injects
   [^GraphTraversalSource g & starts]
   (.inject g (into-array starts)))
-
-(defn V
-  "Returns all vertices matching the supplied ids. If no ids are supplied, returns all vertices."
-  [^GraphTraversalSource g & ids]
-  (.V g (into-array ids)))
 
 (defn with-bulk
   [^GraphTraversalSource g use-bulk]
@@ -125,16 +183,6 @@
     (.withRemote g ^org.apache.tinkerpop.gremlin.process.remote.RemoteConnection conn)))
 
 ; GraphTraversal
-
-(defn addE
-  [^GraphTraversal t label]
-  (.addE t ^String (util/cast-param label)))
-
-(defn addV
-  ([^GraphTraversal t]
-   (.addV t))
-  ([^GraphTraversal t label]
-   (.addV t ^String (util/cast-param label))))
 
 (defn aggregate
   [^GraphTraversal t k]
@@ -667,11 +715,6 @@
   (if (instance? Traversal pred-or-t)
     (.until t ^Traversal pred-or-t)
     (.until t (util/f-to-predicate pred-or-t))))
-
-(defn midV
-  "A mid-traversal V known in Gremlin-Java as just V()"
-  [^GraphTraversal t & ids]
-  (.V t (into-array ids)))
 
 (defn value
   [^GraphTraversal t]

--- a/test/clojure/clojurewerkz/ogre/suite/add_edge_test.clj
+++ b/test/clojure/clojurewerkz/ogre/suite/add_edge_test.clj
@@ -11,7 +11,7 @@
   [g v1Id]
   (q/traverse g (q/V v1Id) (q/as :a)
                 (q/out :created)
-                (q/addE :createdBy)
+                (q/add-E :createdBy)
                 (q/to :a)
                 (q/property :weight 2.0)))
 
@@ -20,7 +20,7 @@
   [g v1Id]
   (q/traverse g (q/V v1Id) (q/as :a)
                 (q/out :created)
-                (q/addE :createdBy)
+                (q/add-E :createdBy)
                 (q/to :a)))
 
 (defn get_g_V_aggregateXxX_asXaX_selectXxX_unfold_addEXexistsWithX_toXaX_propertyXtime_nowX
@@ -30,7 +30,7 @@
                 (q/aggregate :x) (q/as :a)
                 (q/select :x)
                 (q/unfold)
-                (q/addE :existsWith)
+                (q/add-E :existsWith)
                 (q/to :a)
                 (q/property :time "now")))
 
@@ -41,7 +41,7 @@
                 (q/out :created)
                 (q/in :created)
                 (q/where (P/neq "a")) (q/as :b)
-                (q/addE :codeveloper)
+                (q/add-E :codeveloper)
                 (q/from :a)
                 (q/to :b)
                 (q/property :year (int 2009))))
@@ -51,7 +51,7 @@
   [g]
   (q/traverse g (q/V) (q/as :a)
                 (q/in :created)
-                (q/addE :createdBy)
+                (q/add-E :createdBy)
                 (q/from :a)
                 (q/property :year (int 2009))
                 (q/property :acl "public")))
@@ -60,9 +60,9 @@
   "g.addV().as('first').repeat(__.addE('next').to(__.addV()).inV()).times(5).addE('next').to(select('first'))"
   [g]
   (q/traverse g (q/add-V) (q/as :first)
-                (q/repeat (q/__ (q/addE :next) (q/to (q/__ (q/addV))) (q/inV)))
+                (q/repeat (q/__ (q/add-E :next) (q/to (q/__ (q/add-V))) (q/inV)))
                   (q/times 5)
-                (q/addE :next) (q/to (q/__ (q/select :first)))))
+                (q/add-E :next) (q/to (q/__ (q/select :first)))))
 
 
 (defn get_g_withSideEffectXb_bX_VXaX_addEXknowsX_toXbX_propertyXweight_0_5X
@@ -70,7 +70,7 @@
   [g]
   (let [a (q/traverse g (q/V) (q/has :name "marko") (q/next!))
         b (q/traverse g (q/V) (q/has :name "peter") (q/next!))]
-    (q/traverse g (q/with-side-effect :b b) (q/V a) (q/addE :knows) (q/to :b) (q/property :weight 0.5))))
+    (q/traverse g (q/with-side-effect :b b) (q/V a) (q/add-E :knows) (q/to :b) (q/property :weight 0.5))))
 
 (defn get_g_addEXknowsX_fromXaX_toXbX_propertyXweight_0_1X
   "g.addE('knows').from(a).to(b).property('weight', 0.1d)"
@@ -90,6 +90,6 @@
         b (q/traverse g (q/V) (q/has :name "peter") (q/next!))]
     (q/traverse g
                 (q/V a)
-                (q/addE :knows)
+                (q/add-E :knows)
                 (q/to b)
                 (q/property :weight 0.1))))

--- a/test/clojure/clojurewerkz/ogre/suite/add_vertex_test.clj
+++ b/test/clojure/clojurewerkz/ogre/suite/add_vertex_test.clj
@@ -9,7 +9,7 @@
   "g.V(v1Id).as('a').addV('animal').property('age', __.select('a').by('age')).property('name', 'puppy')"
   [g v1Id]
   (q/traverse g (q/V v1Id) (q/as :a)
-                (q/addV :animal)
+                (q/add-V :animal)
                 (q/property :age (q/__ (q/select :a) (q/by :age)))
                 (q/property :name "puppy")))
 
@@ -61,7 +61,7 @@
   "g.V().addV('animal').property('name', __.values('name')).property('name', 'an animal').property(__.values('name'), __.label())"
   [g]
   (q/traverse g (q/V)
-                (q/addV :animal)
+                (q/add-V :animal)
                 (q/property :name (q/__ (q/values :name)))
                 (q/property :name "an animal")
                 (q/property (q/__ (q/values :name)) (q/__ (q/label)))))
@@ -70,7 +70,7 @@
   "g.V().addV('animal').property('age', 0)"
   [g]
   (q/traverse g (q/V)
-                (q/addV :animal)
+                (q/add-V :animal)
                 (q/property :age (int 0))))
 
 (defn get_g_withSideEffectXa_markoX_addV_propertyXname_selectXaXX_name

--- a/test/clojure/clojurewerkz/ogre/suite/graph_test.clj
+++ b/test/clojure/clojurewerkz/ogre/suite/graph_test.clj
@@ -12,7 +12,7 @@
   (q/traverse g (q/V)
                 (q/has :artist "name" "Garcia")
                 (q/in :sungBy) (q/as :song)
-                (q/midV)
+                (q/V)
                 (q/has :artist "name" "Willie_Dixon")
                 (q/in :writtenBy)
                 (q/where (P/eq "song"))
@@ -23,15 +23,15 @@
   [g]
   (q/traverse g (q/V)
                 (q/has-label :person) (q/as :p)
-                (q/midV ^List  (q/traverse g (q/V) (q/has-label :software) (q/into-list!)))
-                (q/addE :uses)
+                (q/V ^List  (q/traverse g (q/V) (q/has-label :software) (q/into-list!)))
+                (q/add-E :uses)
                 (q/from :p)))
 
 (defn get_g_VX1X_V_valuesXnameX
   "g.V(v1Id).V().values('name')"
   [g v1Id]
   (q/traverse g (q/V v1Id)
-                (q/midV)
+                (q/V)
                 (q/values :name)))
 
 (defn get_g_V_outXknowsX_V_name
@@ -39,5 +39,5 @@
   [g]
   (q/traverse g (q/V)
                 (q/out :knows)
-                (q/midV)
+                (q/V)
                 (q/values :name)))

--- a/test/clojure/clojurewerkz/ogre/suite/optional_test.clj
+++ b/test/clojure/clojurewerkz/ogre/suite/optional_test.clj
@@ -35,5 +35,5 @@
   "g.V(v1Id).optional(addV('dog')).label()"
   [g v1Id]
   (q/traverse g (q/V v1Id)
-                (q/optional (q/__ (q/addV "dog")))
+                (q/optional (q/__ (q/add-V "dog")))
               (q/label)))

--- a/test/clojure/clojurewerkz/ogre/suite/vertex_test.clj
+++ b/test/clojure/clojurewerkz/ogre/suite/vertex_test.clj
@@ -184,7 +184,7 @@
   [g]
   (q/traverse g (q/V)
                 (q/has-label :person)
-                (q/midV)
+                (q/V)
                 (q/has-label :software)
                 (q/values :name)))
 


### PR DESCRIPTION
This commit moves the following functions into multimethods
that work for both GraphTraversal and GraphTraversalSource objects
* add-V
* addV
* add-E
* addE
* V
* midV

Both versions of the fuctions are maintained to preserve
backwards compatibility of the API.