### PR TITLE
Clean up dependencies via project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,19 +4,19 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :aot :all
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [potemkin "0.3.12"]
-                 [org.apache.tinkerpop/gremlin-core "3.3.1"]
-                 [org.apache.tinkerpop/gremlin-test "3.3.1"  :scope "test"]
-                 [org.apache.tinkerpop/tinkergraph-gremlin "3.3.1" :scope "test"]
-                 [org.slf4j/slf4j-log4j12 "1.7.21" :scope "test"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [potemkin "0.4.4"]
+                 [org.apache.tinkerpop/gremlin-core "3.3.1"]]
   :source-paths ["src/clojure"]
   :java-source-paths ["test/java"]
   :resource-paths ["test/resources"]
   :profiles {:dev    { :global-vars {*assert* true}
                        :dependencies [[clojurewerkz/support "1.1.0" :exclusions [org.clojure/clojure]]
-                                      [commons-io/commons-io "2.4"]]}
-             :master { :dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}}
+                                      [commons-io/commons-io "2.6"]
+                                      [org.apache.tinkerpop/gremlin-test "3.3.1"  :scope "test"]
+                                      [org.apache.tinkerpop/tinkergraph-gremlin "3.3.1" :scope "test"]
+                                      [org.slf4j/slf4j-log4j12 "1.7.25" :scope "test"]]}
+             :master {}}
   :aliases {"all" ["with-profile" "dev,dev:master"]}
   :repositories {"sonatype" {:url "https://oss.sonatype.org/content/repositories/releases"
                              :snapshots false

--- a/project.clj
+++ b/project.clj
@@ -3,20 +3,20 @@
   :url "https://github.com/clojurewerkz/ogre"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :aot :all
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [potemkin "0.3.12"]
-                 [org.apache.tinkerpop/gremlin-core "3.3.1"]
-                 [org.apache.tinkerpop/gremlin-test "3.3.1"  :scope "test"]
-                 [org.apache.tinkerpop/tinkergraph-gremlin "3.3.1" :scope "test"]
-                 [org.slf4j/slf4j-log4j12 "1.7.21" :scope "test"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [potemkin "0.4.4"]
+                 [org.apache.tinkerpop/gremlin-core "3.3.1"]]
   :source-paths ["src/clojure"]
-  :java-source-paths ["test/java"]
-  :resource-paths ["test/resources"]
-  :profiles {:dev    { :global-vars {*assert* true}
-                       :dependencies [[clojurewerkz/support "1.1.0" :exclusions [org.clojure/clojure]]
-                                      [commons-io/commons-io "2.4"]]}
-             :master { :dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}}
+  :profiles {:dev {:global-vars {*assert* true}
+                   :dependencies [[clojurewerkz/support "1.1.0" :exclusions [org.clojure/clojure]]
+                                  [commons-io/commons-io "2.6"]
+                                  [org.apache.tinkerpop/gremlin-test "3.3.1"  :scope "test"]
+                                  [org.apache.tinkerpop/tinkergraph-gremlin "3.3.1" :scope "test"]
+                                  [org.slf4j/slf4j-log4j12 "1.7.25" :scope "test"]]
+                   :resource-paths ["test/resources"]
+                   :java-source-paths ["test/java"]
+                   :junit ["test/java"]}
+             :uberjar {:aot :all}}
   :aliases {"all" ["with-profile" "dev,dev:master"]}
   :repositories {"sonatype" {:url "https://oss.sonatype.org/content/repositories/releases"
                              :snapshots false
@@ -25,7 +25,6 @@
                                        :snapshots true
                                        :releases {:checksum :fail :update :always}}}
   :plugins [[lein-junit "1.1.8"]]
-  :junit ["test/java"]
-  :test-paths ["test/clojure"]
+  :test-paths ["test/clojure" "test/java"]
   :global-vars {*warn-on-reflection* true
                 *assert* false})

--- a/project.clj
+++ b/project.clj
@@ -25,6 +25,6 @@
                                        :snapshots true
                                        :releases {:checksum :fail :update :always}}}
   :plugins [[lein-junit "1.1.8"]]
-  :test-paths ["test/clojure" "test/java"]
+  :test-paths ["test/clojure"]
   :global-vars {*warn-on-reflection* true
                 *assert* false})

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojurewerkz/ogre "3.3.1.0"
+(defproject clojurewerkz/ogre "3.3.2.0-SNAPSHOT"
   :description "Clojure library for traversing Apache TinkerPop enabled graphs and a dialect of the Gremlin graph processing language"
   :url "https://github.com/clojurewerkz/ogre"
   :license {:name "Eclipse Public License"

--- a/project.clj
+++ b/project.clj
@@ -4,19 +4,19 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :aot :all
-  :dependencies [[org.clojure/clojure "1.9.0"]
-                 [potemkin "0.4.4"]
-                 [org.apache.tinkerpop/gremlin-core "3.3.1"]]
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [potemkin "0.3.12"]
+                 [org.apache.tinkerpop/gremlin-core "3.3.1"]
+                 [org.apache.tinkerpop/gremlin-test "3.3.1"  :scope "test"]
+                 [org.apache.tinkerpop/tinkergraph-gremlin "3.3.1" :scope "test"]
+                 [org.slf4j/slf4j-log4j12 "1.7.21" :scope "test"]]
   :source-paths ["src/clojure"]
   :java-source-paths ["test/java"]
   :resource-paths ["test/resources"]
   :profiles {:dev    { :global-vars {*assert* true}
                        :dependencies [[clojurewerkz/support "1.1.0" :exclusions [org.clojure/clojure]]
-                                      [commons-io/commons-io "2.6"]
-                                      [org.apache.tinkerpop/gremlin-test "3.3.1"  :scope "test"]
-                                      [org.apache.tinkerpop/tinkergraph-gremlin "3.3.1" :scope "test"]
-                                      [org.slf4j/slf4j-log4j12 "1.7.25" :scope "test"]]}
-             :master {}}
+                                      [commons-io/commons-io "2.4"]]}
+             :master { :dependencies [[org.clojure/clojure "1.9.0-master-SNAPSHOT"]]}}
   :aliases {"all" ["with-profile" "dev,dev:master"]}
   :repositories {"sonatype" {:url "https://oss.sonatype.org/content/repositories/releases"
                              :snapshots false


### PR DESCRIPTION
- Bumped dependency versions for potemkin, clojure, common-io, and slf4j via lein ancient
- Moved dependencies that were only being used for testing into the `:dev` profile
  - This fixed a dependency conflict I was having with `clj-tuple`
  - These test dependencies do not need to get bundled into the jar
- Tests are passing locally and can install locally