### PR TITLE
support gremlin 3.3.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,13 +5,13 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [potemkin "0.4.4"]
-                 [org.apache.tinkerpop/gremlin-core "3.3.2"]]
+                 [org.apache.tinkerpop/gremlin-core "3.3.3"]]
   :source-paths ["src/clojure"]
   :profiles {:dev {:global-vars {*assert* true}
                    :dependencies [[clojurewerkz/support "1.1.0" :exclusions [org.clojure/clojure]]
                                   [commons-io/commons-io "2.6"]
-                                  [org.apache.tinkerpop/gremlin-test "3.3.2"  :scope "test"]
-                                  [org.apache.tinkerpop/tinkergraph-gremlin "3.3.2" :scope "test"]
+                                  [org.apache.tinkerpop/gremlin-test "3.3.3"  :scope "test"]
+                                  [org.apache.tinkerpop/tinkergraph-gremlin "3.3.3" :scope "test"]
                                   [org.slf4j/slf4j-log4j12 "1.7.25" :scope "test"]]
                    :resource-paths ["test/resources"]
                    :java-source-paths ["test/java"]

--- a/src/clojure/clojurewerkz/ogre/core.clj
+++ b/src/clojure/clojurewerkz/ogre/core.clj
@@ -621,13 +621,16 @@
 
 (defn select
   ([^GraphTraversal t arg1]
-   (if (instance? Column arg1)
-     (.select t ^Column arg1)
+   (condp instance? arg1
+     Column (.select t ^Column arg1)
+     Traversal (.select t ^Traversal arg1)
      (.select t ^String (util/cast-param arg1))))
   ([^GraphTraversal t arg1 & args]
    (if (instance? Pop arg1)
      (if (= (clojure.core/count args) 1)
-       (.select t ^Pop arg1 (util/cast-param (first args)))
+       (condp instance? (first args)
+         Traversal (.select t ^Traversal (first args))
+         (.select t ^Pop arg1 (util/cast-param (first args))))
        (.select t ^Pop arg1 (util/cast-param (first args)) (util/cast-param (second args)) (util/keywords-to-str-array (take-last 2 args))))
      (.select t ^String (util/cast-param arg1) (util/cast-param (first args)) (util/keywords-to-str-array (rest args))))))
 

--- a/test/clojure/clojurewerkz/ogre/suite/add_vertex_test.clj
+++ b/test/clojure/clojurewerkz/ogre/suite/add_vertex_test.clj
@@ -108,5 +108,12 @@
               (q/add-V (q/__ (q/V) (q/has :name "marko") (q/properties :name) (q/key)))
               (q/label)))
 
-
+(defn get_g_withSideEffectXa_nameX_addV_propertyXselectXaX_markoX_name
+  "g.withSideEffect('a', 'name').addV().property(select('a'),'marko').values('name')"
+  [g]
+  (q/traverse g
+              (q/with-side-effect :a "name")
+              (q/add-V)
+              (q/property (q/__ (q/select :a)) "marko")
+              (q/values :name)))
 

--- a/test/clojure/clojurewerkz/ogre/suite/select_test.clj
+++ b/test/clojure/clojurewerkz/ogre/suite/select_test.clj
@@ -357,3 +357,38 @@
                 (q/repeat (q/__ (q/out) (q/as :a)))
                   (q/times 2)
                 (q/select (Pop/first) :a)))
+
+(defn get_g_V_asXaX_outXknowsX_asXaX_selectXall_constantXaXX
+  "g.V().as('a').out('knows').as('a').select(Pop.all, (Traversal) __.constant('a'))"
+  [g]
+  (q/traverse g
+              q/V (q/as :a)
+              (q/out :knows) (q/as :a)
+              (q/select (Pop/all) (q/__ (q/constant "a")))))
+
+(defn get_g_V_asXaX_groupXmX_by_byXbothE_countX_barrier_selectXmX_selectXselectXaXX_byXmathX_plus_XX
+  "g.V().as('a').group('m').by().by(__.bothE().count()).barrier().select('m').<Double>select(__.select('a')).by(__.math('_+_'))"
+  [g]
+  (q/traverse g
+              (q/V) (q/as :a)
+              (q/group :m)
+              (q/by)
+              (q/by (q/__ (q/bothE)
+                          (q/count)))
+              (q/barrier)
+              (q/select :m)
+              (q/select (q/__ (q/select :a)))
+              (q/by (q/__ (q/math "_+_")))))
+
+(defn get_g_V_asXaX_groupXmX_by_byXbothE_countX_barrier_selectXmX_selectXselectXaXX
+  "g.V().as('a').group('m').by().by(__.bothE().count()).barrier().select('m').select(__.select('a'))"
+  [g]
+  (q/traverse g
+              (q/V) (q/as :a)
+              (q/group :m)
+              (q/by)
+              (q/by (q/__ (q/bothE)
+                          (q/count)))
+              (q/barrier)
+              (q/select :m)
+              (q/select (q/__ (q/select :a)))))

--- a/test/java/org/clojurewerkz/ogre/gremlin/process/OgreTinkerPopCheck.java
+++ b/test/java/org/clojurewerkz/ogre/gremlin/process/OgreTinkerPopCheck.java
@@ -1447,6 +1447,12 @@ public static IFn require = Clojure.var("clojure.core", "require");
             return (org.apache.tinkerpop.gremlin.process.traversal.Traversal) Clojure.var(NS, "get_g_addVXV_hasXname_markoX_propertiesXnameX_keyX_label").invoke(g);
         }
 
+        @Override
+        @SuppressWarnings("unchecked")
+        public org.apache.tinkerpop.gremlin.process.traversal.Traversal get_g_withSideEffectXa_nameX_addV_propertyXselectXaX_markoX_name() {
+            return (org.apache.tinkerpop.gremlin.process.traversal.Traversal) Clojure.var(NS, "get_g_withSideEffectXa_nameX_addV_propertyXselectXaX_markoX_name").invoke(g);
+        }
+
     }
 
     public static class CoalesceTestTraversals extends CoalesceTest {
@@ -2401,6 +2407,23 @@ public static IFn require = Clojure.var("clojure.core", "require");
             return (org.apache.tinkerpop.gremlin.process.traversal.Traversal) Clojure.var(NS, "get_g_VX1X_asXaX_repeatXout_asXaXX_timesX2X_selectXfirst_aX").invoke(g, arg0);
         }
 
+        @Override
+        @SuppressWarnings("unchecked")
+        public org.apache.tinkerpop.gremlin.process.traversal.Traversal get_g_V_asXaX_outXknowsX_asXaX_selectXall_constantXaXX() {
+            return (org.apache.tinkerpop.gremlin.process.traversal.Traversal) Clojure.var(NS, "get_g_V_asXaX_outXknowsX_asXaX_selectXall_constantXaXX").invoke(g);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public org.apache.tinkerpop.gremlin.process.traversal.Traversal get_g_V_asXaX_groupXmX_by_byXbothE_countX_barrier_selectXmX_selectXselectXaXX_byXmathX_plus_XX() {
+            return (org.apache.tinkerpop.gremlin.process.traversal.Traversal) Clojure.var(NS, "get_g_V_asXaX_groupXmX_by_byXbothE_countX_barrier_selectXmX_selectXselectXaXX_byXmathX_plus_XX").invoke(g);
+}
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public org.apache.tinkerpop.gremlin.process.traversal.Traversal get_g_V_asXaX_groupXmX_by_byXbothE_countX_barrier_selectXmX_selectXselectXaXX() {
+            return  (org.apache.tinkerpop.gremlin.process.traversal.Traversal) Clojure.var(NS, "get_g_V_asXaX_groupXmX_by_byXbothE_countX_barrier_selectXmX_selectXselectXaXX").invoke(g);
+        }
     }
 
     public static class VertexTestTraversals extends VertexTest {


### PR DESCRIPTION
When I bumped the gremlin version to 3.3.3 and ran the tests the compiler noted that four tests were missing. I added support for the new select methods that take Traversals as arguments which I discovered as a new feature when implementing the missing tests. I did not add any other additional features. `lein test` is successful on my machine with these changes.